### PR TITLE
IOS-4512 run solana requests in main thread

### DIFF
--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -95,6 +95,7 @@ public class NetworkingRouter: SolanaRouter {
                 }
             }
             .retry(2)
+            .receive(on: RunLoop.main)
             .sink(receiveCompletion: { [weak self] completion in
                 guard let self = self else { return }
                 


### PR DESCRIPTION
Исходные данные такие:

* краши начались в середине сентября в 4.11.0 (но 4.10 тоже иногда падает)
* ничего такого в этом фреймворке или в клиентском коде не меняли
* падает при запросах загрузки баланса, в логах приложения последнее что есть — его открытие
* падает при изменении NetworkingRouter.bag из негуёвого потока
* из негуёвого потока мы посылаем запросы только если было переключение апишек (попадаем в sink(receiveCompletion:) и оттуда вызываем self.retry

```
Fatal Exception: NSInvalidArgumentException
-[__NSTaggedDate member:]: unrecognized selector sent to instance 0x8000000000000000
```

Из похожих проблем нашел у людей когда падало при попытке удалить подписку из другого потока

Пробовал воспроизвести, сделал переключение апишек чтобы мы посылали запросы из негуёвого потока и соответственно оттуда же обращались к bag, 1000 обновлений WalletModel.update в цикле и уничтожение `walletModel = nil` посреди цикла, но ничего не падало.