### PR TITLE
IOS-5792: Add SPM dependencies support

### DIFF
--- a/Solana.Swift.podspec
+++ b/Solana.Swift.podspec
@@ -18,7 +18,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/Solana/**/*'
   s.swift_versions   = ["5.3"]
 
+  # 'secp256k1.swift' dependency must be added via SPM
+
   s.dependency 'TweetNacl', '~> 1.0.2'
   s.dependency 'Starscream', '4.0.4'
-  s.dependency 'secp256k1.swift'
 end


### PR DESCRIPTION
[IOS-5792](https://tangem.atlassian.net/browse/IOS-5792)

Убрана CocoaPods зависимость `secp256k1.swift` в подспеке (теперь она подключается через SPM потребителем)


[IOS-5792]: https://tangem.atlassian.net/browse/IOS-5792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ