### PR TITLE
Bugfix/ios 6504 fix blockhash error

### DIFF
--- a/Solana.Swift.xcodeproj/project.pbxproj
+++ b/Solana.Swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D79B1502C00C04600E71EBB /* getLatestBlockhash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D79B14F2C00C04600E71EBB /* getLatestBlockhash.swift */; };
 		7DD945E699E2BF12EB4681AD /* Pods_Solana_SwiftTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1E8409193B12E3A8D5A9D41 /* Pods_Solana_SwiftTests.framework */; };
 		A31C023BA53A7F24397E6930 /* Pods_Solana_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 331172706474BFC5CA7C4B9A /* Pods_Solana_Swift.framework */; };
 		B03AE9662901828D003E18BC /* Solana_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B03AE95D2901828D003E18BC /* Solana_Swift.framework */; };
@@ -194,6 +195,7 @@
 
 /* Begin PBXFileReference section */
 		0746F5898207426EE9C0D17E /* Pods-Solana.SwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Solana.SwiftTests.release.xcconfig"; path = "Target Support Files/Pods-Solana.SwiftTests/Pods-Solana.SwiftTests.release.xcconfig"; sourceTree = "<group>"; };
+		2D79B14F2C00C04600E71EBB /* getLatestBlockhash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = getLatestBlockhash.swift; sourceTree = "<group>"; };
 		331172706474BFC5CA7C4B9A /* Pods_Solana_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Solana_Swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		625790C608CCEEA2EB711B59 /* Pods-Solana.Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Solana.Swift.debug.xcconfig"; path = "Target Support Files/Pods-Solana.Swift/Pods-Solana.Swift.debug.xcconfig"; sourceTree = "<group>"; };
 		81AE72A72337C0C9BEC637D2 /* Pods-Solana.SwiftTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Solana.SwiftTests.debug.xcconfig"; path = "Target Support Files/Pods-Solana.SwiftTests/Pods-Solana.SwiftTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -1087,6 +1089,7 @@
 			isa = PBXGroup;
 			children = (
 				B03AEBCE290185C5003E18BC /* getRecentBlockhash.swift */,
+				2D79B14F2C00C04600E71EBB /* getLatestBlockhash.swift */,
 			);
 			path = getRecentBlockhash;
 			sourceTree = "<group>";
@@ -1696,6 +1699,7 @@
 				B03AEC26290185C5003E18BC /* closeTokenAccount.swift in Sources */,
 				B03AEC66290185C6003E18BC /* Int2X.swift in Sources */,
 				B03AEC63290185C6003E18BC /* SHA256.swift in Sources */,
+				2D79B1502C00C04600E71EBB /* getLatestBlockhash.swift in Sources */,
 				B03AEC5E290185C6003E18BC /* getClusterNodes.swift in Sources */,
 				B03AEC40290185C6003E18BC /* getRecentPerformanceSamples.swift in Sources */,
 				B03AEC49290185C6003E18BC /* getBlockCommitment.swift in Sources */,

--- a/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
+++ b/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
@@ -59,7 +59,7 @@ extension Action {
         if let recentBlockhash = recentBlockhash {
             getRecentBlockhashRequest(.success(recentBlockhash))
         } else {
-            self.api.getRecentBlockhash { getRecentBlockhashRequest($0) }
+            self.api.getLatestBlockhash(onComplete: getRecentBlockhashRequest)
         }
     }
 }

--- a/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
+++ b/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public extension Api {
+    func getLatestBlockhash(commitment: Commitment? = nil, onComplete: @escaping(Result<String, Error>) -> Void) {
+        router.request(parameters: [RequestConfiguration(commitment: commitment)]) { (result: Result<Rpc<LatestBlockhash?>, Error>) in
+            switch result {
+            case .success(let rpc):
+                guard let value = rpc.value else {
+                    onComplete(.failure(SolanaError.nullValue))
+                    return
+                }
+                guard let blockhash = value.blockhash else {
+                    onComplete(.failure(SolanaError.blockHashNotFound))
+                    return
+                }
+                onComplete(.success(blockhash))
+            case .failure(let error):
+                onComplete(.failure(error))
+            }
+        }
+    }
+}
+
+public extension ApiTemplates {
+    struct GetLatestBlockhash: ApiTemplate {
+        public init(commitment: Commitment? = nil) {
+            self.commitment = commitment
+        }
+        
+        public let commitment: Commitment?
+        
+        public typealias Success = String
+        
+        public func perform(withConfigurationFrom apiClass: Api, completion: @escaping (Result<Success, Error>) -> Void) {
+            apiClass.getLatestBlockhash(commitment: commitment, onComplete: completion)
+        }
+    }
+}

--- a/Sources/Solana/Models/SolanaSDK+Models.swift
+++ b/Sources/Solana/Models/SolanaSDK+Models.swift
@@ -83,6 +83,10 @@ public struct Fee: Decodable {
     public let blockhash: String?
     public let lastValidSlot: UInt64?
 }
+public struct LatestBlockhash: Decodable {
+    public let blockhash: String?
+    public let lastValidBlockHeight: UInt64?
+}
 public struct FeeCalculator: Decodable {
     public let lamportsPerSignature: Lamports
 }

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -133,7 +133,7 @@ public class NetworkingRouter: SolanaRouter {
                     return
                 }
                 
-                self.apiLogger?.handle(error: "Failed to send request: \(bcMethod). error = \(error)")
+                self.apiLogger?.handle(error: "Failed to send request: \(bcMethod). Error = \(error)")
                 onComplete(.failure(error))
             }, receiveValue: { })
     }

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -38,8 +38,6 @@ public class NetworkingRouter: SolanaRouter {
     
     private var currentEndpointIndex = 0
     
-    private var subscription: AnyCancellable?
-    
     // MARK: - Init
     
     public init(endpoints: [RPCEndpoint], session: URLSession = .shared, apiLogger: NetworkingRouterSwitchApiLogger?) {
@@ -73,6 +71,7 @@ public class NetworkingRouter: SolanaRouter {
             onComplete(.failure(error))
         }
         
+        var subscription: AnyCancellable?
         subscription = urlSession.dataTaskPublisher(for: request)
             .tryMap { (data: Data?, response: URLResponse) -> Void in
                 guard let httpURLResponse = response as? HTTPURLResponse else {

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -38,6 +38,10 @@ public class NetworkingRouter: SolanaRouter {
     
     private var currentEndpointIndex = 0
     
+    private var subscription: AnyCancellable?
+    
+    // MARK: - Init
+    
     public init(endpoints: [RPCEndpoint], session: URLSession = .shared, apiLogger: NetworkingRouterSwitchApiLogger?) {
         self.endpoints = endpoints
         self.urlSession = session
@@ -69,7 +73,6 @@ public class NetworkingRouter: SolanaRouter {
             onComplete(.failure(error))
         }
         
-        var subscription: AnyCancellable?
         subscription = urlSession.dataTaskPublisher(for: request)
             .tryMap { (data: Data?, response: URLResponse) -> Void in
                 guard let httpURLResponse = response as? HTTPURLResponse else {


### PR DESCRIPTION
- !!! Убрал retry(2) по ресерчу убедится не могу, но вроде обсудили с Андроид, у них такого нет, и в случае если ендпоинт nowNodes стреляет долго по времени, там летит пачка запросов, можем тайм аут ловить долгий и за это время устаревает blockhash

- Добавил логирование для роутера

- Переехал на обновленный метод LatestBlockhash , потому что ReceantBlockhash считается deprecated (к обсуждению, могу отключить)

- Привел процесс переключения к нашему в виду в BSDK

Прикладываю логи например переключения из nownodes по 422 для 3х запросов которые летят пачкой

❌ 17:16:23:026: Switchable publisher catched error: httpErrorCode(422) host: sol.nownodes.io
❌ 17:16:23:089: Switchable publisher catched error: httpErrorCode(422) host: sol.nownodes.io
❌ 17:16:23:089: Switchable publisher catched error: httpErrorCode(422) host: sol.nownodes.io