### PR TITLE
IOS-7219 Make disable retry for send solana transaction

### DIFF
--- a/Sources/Solana/Api/sendTransaction/sendTransaction.swift
+++ b/Sources/Solana/Api/sendTransaction/sendTransaction.swift
@@ -4,7 +4,7 @@ public extension Api {
     func sendTransaction(serializedTransaction: String,
                          configs: RequestConfiguration = RequestConfiguration(encoding: "base64", maxRetries: 12)!,
                          onComplete: @escaping(Result<TransactionID, Error>) -> Void) {
-        router.request(parameters: [serializedTransaction, configs], enableRetry: false) { (result: Result<TransactionID, Error>) in
+        router.request(parameters: [serializedTransaction, configs], enableСontinuedRetry: false) { (result: Result<TransactionID, Error>) in
             switch result {
             case .success(let transaction):
                 onComplete(.success(transaction))

--- a/Sources/Solana/Api/sendTransaction/sendTransaction.swift
+++ b/Sources/Solana/Api/sendTransaction/sendTransaction.swift
@@ -4,7 +4,7 @@ public extension Api {
     func sendTransaction(serializedTransaction: String,
                          configs: RequestConfiguration = RequestConfiguration(encoding: "base64", maxRetries: 12)!,
                          onComplete: @escaping(Result<TransactionID, Error>) -> Void) {
-        router.request(parameters: [serializedTransaction, configs]) { (result: Result<TransactionID, Error>) in
+        router.request(parameters: [serializedTransaction, configs], enableRetry: false) { (result: Result<TransactionID, Error>) in
             switch result {
             case .success(let transaction):
                 onComplete(.success(transaction))

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -50,7 +50,7 @@ public class NetworkingRouter: SolanaRouter {
         method: HTTPMethod = .post,
         bcMethod: String = #function,
         parameters: [Encodable?] = [],
-        enableRetry: Bool = true,
+        enableСontinuedRetry: Bool = true,
         onComplete: @escaping (Result<T, Error>) -> Void
     ) {
         let bcMethod = bcMethod.replacingOccurrences(of: "\\([\\w\\s:]*\\)", with: "", options: .regularExpression)
@@ -125,8 +125,11 @@ public class NetworkingRouter: SolanaRouter {
                     return
                 }
                 
-                // 'enableRetry' flag used for forced shutdown retry cycle
-                if self.needRetry(for: url.host, with: enableRetry) {
+                /*
+                 'enableСontinuedRetry' flag used for forced shutdown retry cycle, default value - true
+                 Do not confuse the order of checking the conditions, because there must be api switching at least once
+                 */
+                if self.needRetry(for: url.host) && enableСontinuedRetry {
                     if url.host != host {
                         self.apiLogger?.handle(error: error, currentHost: url.host ?? "", nextHost: self.host ?? "")
                     }
@@ -142,14 +145,14 @@ public class NetworkingRouter: SolanaRouter {
             }, receiveValue: { })
     }
     
-    private func needRetry(for errorHost: String?, with enableRetry: Bool) -> Bool {
+    private func needRetry(for errorHost: String?) -> Bool {
         if self.host != errorHost {
             return true
         }
         
         currentEndpointIndex += 1
         if currentEndpointIndex < endpoints.count {
-            return enableRetry
+            return true
         }
         
         currentEndpointIndex = 0

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -125,7 +125,7 @@ public class NetworkingRouter: SolanaRouter {
                     return
                 }
                 
-                // "needRetry" flag used for forced shutdown retry cycle
+                // 'enableRetry' flag used for forced shutdown retry cycle
                 if self.needRetry(for: url.host, with: enableRetry) {
                     if url.host != host {
                         self.apiLogger?.handle(error: error, currentHost: url.host ?? "", nextHost: self.host ?? "")
@@ -149,7 +149,6 @@ public class NetworkingRouter: SolanaRouter {
         
         currentEndpointIndex += 1
         if currentEndpointIndex < endpoints.count {
-            // Used for forced shutdown switched api
             return enableRetry
         }
         

--- a/Sources/Solana/Networking/Router/SolanaRouter.swift
+++ b/Sources/Solana/Networking/Router/SolanaRouter.swift
@@ -6,7 +6,7 @@ import Foundation
  Most use cases can prefer `NetworkingRouter` for daily use. Conform to this with a cusstom implementation to create local integration test tooling.
  */
 public protocol SolanaRouter {
-    func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable
+    func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], enableRetry: Bool, onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable
 
     var endpoint: RPCEndpoint  { get }
 }

--- a/Sources/Solana/Networking/Router/SolanaRouter.swift
+++ b/Sources/Solana/Networking/Router/SolanaRouter.swift
@@ -6,7 +6,7 @@ import Foundation
  Most use cases can prefer `NetworkingRouter` for daily use. Conform to this with a cusstom implementation to create local integration test tooling.
  */
 public protocol SolanaRouter {
-    func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], enableRetry: Bool, onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable
+    func request<T>(method: HTTPMethod, bcMethod: String, parameters: [Encodable?], enableСontinuedRetry: Bool, onComplete: @escaping (Result<T, Error>) -> Void) where T : Decodable
 
     var endpoint: RPCEndpoint  { get }
 }


### PR DESCRIPTION
Небольшие изменения для выключения переключений API на сенде.

Ожидаемый результат работы, при получении ошибки на сенде смотрим флаг разрешения переключения, если разрешен делаем переключение апи, но если отключен выкидываем ошибку, при этом делаем изменения индекса провайдера