### PR TITLE
IOS-7219 Add disable switch api for recent block hash method

### DIFF
--- a/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
+++ b/Sources/Solana/Actions/serializeTransaction/serializeTransaction.swift
@@ -59,7 +59,9 @@ extension Action {
         if let recentBlockhash = recentBlockhash {
             getRecentBlockhashRequest(.success(recentBlockhash))
         } else {
-            self.api.getLatestBlockhash(onComplete: getRecentBlockhashRequest)
+            // Disable need retry for send only
+            let needRetry = mode == .serializeOnly
+            self.api.getLatestBlockhash(enableСontinuedRetry: needRetry, onComplete: getRecentBlockhashRequest)
         }
     }
 }

--- a/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
+++ b/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public extension Api {
-    func getLatestBlockhash(commitment: Commitment? = nil, onComplete: @escaping(Result<String, Error>) -> Void) {
-        router.request(parameters: [RequestConfiguration(commitment: commitment)]) { (result: Result<Rpc<LatestBlockhash?>, Error>) in
+    func getLatestBlockhash(commitment: Commitment? = nil, enableСontinuedRetry: Bool = true, onComplete: @escaping(Result<String, Error>) -> Void) {
+        router.request(parameters: [RequestConfiguration(commitment: commitment)], enableСontinuedRetry: enableСontinuedRetry) { (result: Result<Rpc<LatestBlockhash?>, Error>) in
             switch result {
             case .success(let rpc):
                 guard let value = rpc.value else {


### PR DESCRIPTION
В запросе отправке также летит запрос getRecentBlockhash, при полной блокировке апи, чтобы выровнять нужное поведение нужно исключать переключение этого запроса

Исключается путем определения условия, что транзакции сериализуется для подписи