### PR TITLE
Connect tweetnacl dependency via spm

### DIFF
--- a/Solana.Swift.podspec
+++ b/Solana.Swift.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.swift_versions   = ["5.3"]
 
   # 'secp256k1.swift' dependency must be added via SPM
-
-  s.dependency 'TweetNacl', '~> 1.0.2'
+  # 'TweetNacl' dependency must be added via SPM
+  
   s.dependency 'Starscream', '4.0.8'
 end


### PR DESCRIPTION
В рамках переезда BigInt на SPM нужно перевести TonSwift, который зависит от TweetNacl. В итоге TweetNacl должен также подключаться через SPM.