### PR TITLE
IOS-7728 Use confirmed commitment for blockhash request

### DIFF
--- a/Sources/Solana/Actions/sendSOL/sendSOL.swift
+++ b/Sources/Solana/Actions/sendSOL/sendSOL.swift
@@ -8,7 +8,7 @@ extension Action {
         computeUnitPrice: UInt64?,
         allowUnfundedRecipient: Bool = false,
         fromPublicKey: PublicKey,
-        onComplete: @escaping ((Result<String, Error>) -> Void)
+        onComplete: @escaping ((Result<(String, Date), Error>) -> Void)
     ) {
         checkTransaction(
             to: destination,
@@ -119,7 +119,7 @@ extension Action {
         amount: UInt64,
         computeUnitLimit: UInt32?,
         computeUnitPrice: UInt64?,
-        onComplete: @escaping ((Result<String, Error>) -> Void)
+        onComplete: @escaping ((Result<(String, Date), Error>) -> Void)
     ) {
         let instructionsResult = sendSolInstructions(from: fromPublicKey, to: destination, amount: amount, computeUnitLimit: computeUnitLimit, computeUnitPrice: computeUnitPrice)
         

--- a/Sources/Solana/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
+++ b/Sources/Solana/Actions/serializeAndSendWithFee/serializeAndSendWithFee.swift
@@ -57,9 +57,9 @@ extension Action {
             self.serializeTransaction(instructions: instructions, recentBlockhash: recentBlockhash, signers: signers, mode: .serializeAndSign) {
                 cb($0)
             }
-        }.flatMap { transaction in
+        }.flatMap { (transaction, timestamp) in
             return ContResult.init { cb in
-                self.api.sendTransaction(serializedTransaction: transaction) {
+                self.api.sendTransaction(serializedTransaction: transaction, startSendingTimestamp: timestamp) {
                     cb($0)
                 }
             }
@@ -131,7 +131,7 @@ extension Action {
         serializeTransaction(instructions: instructions, recentBlockhash: recentBlockhash, signers: signers, mode: .serializeAndSign) { result in
             switch result {
             case .success(let transaction):
-                self.api.simulateTransaction(transaction: transaction) {
+                self.api.simulateTransaction(transaction: transaction.0) {
                     switch $0 {
                     case .success(let r):
                         if r.err != nil {

--- a/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
+++ b/Sources/Solana/Api/getRecentBlockhash/getLatestBlockhash.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public extension Api {
-    func getLatestBlockhash(commitment: Commitment? = nil, enableСontinuedRetry: Bool = true, onComplete: @escaping(Result<String, Error>) -> Void) {
+    func getLatestBlockhash(commitment: Commitment? = "confirmed", enableСontinuedRetry: Bool = true, onComplete: @escaping(Result<String, Error>) -> Void) {
         router.request(parameters: [RequestConfiguration(commitment: commitment)], enableСontinuedRetry: enableСontinuedRetry) { (result: Result<Rpc<LatestBlockhash?>, Error>) in
             switch result {
             case .success(let rpc):

--- a/Sources/Solana/Api/sendTransaction/sendTransaction.swift
+++ b/Sources/Solana/Api/sendTransaction/sendTransaction.swift
@@ -4,12 +4,12 @@ public extension Api {
     func sendTransaction(serializedTransaction: String,
                          configs: RequestConfiguration = RequestConfiguration(encoding: "base64", maxRetries: 12)!,
                          startSendingTimestamp: Date,
-                         retries: Int = Constants.maxRetries,
+                         retries: TimeInterval = Constants.maxRetries,
                          onComplete: @escaping(Result<TransactionID, Error>) -> Void) {
         let elapsed = Date().timeIntervalSince(startSendingTimestamp)
 
         // Too early to send, waiting
-        if elapsed < Constants.retryTimeoutSeconds {
+        if elapsed < Constants.retryStartTimeoutSeconds {
             Thread.sleep(forTimeInterval: Constants.waitingDelaySeconds)
             sendTransaction(serializedTransaction: serializedTransaction,
                             configs: configs,
@@ -88,12 +88,12 @@ public extension ApiTemplates {
     }
 }
 
-private extension Api {
+public extension Api {
     enum Constants {
         /// According to blockchain specifications and blockhain analytic
         static let retryStartTimeoutSeconds: TimeInterval = 15
         static let waitingDelaySeconds: TimeInterval = 1
         static let retryDelaySeconds: TimeInterval = 3
-        static let maxRetries: TimeInterval = 5
+        public static let maxRetries: TimeInterval = 5
     }
 }

--- a/Sources/Solana/Api/sendTransaction/sendTransaction.swift
+++ b/Sources/Solana/Api/sendTransaction/sendTransaction.swift
@@ -10,7 +10,7 @@ public extension Api {
 
         // Too early to send, waiting
         if elapsed < Constants.retryTimeoutSeconds {
-            Thread.sleep(forTimeInterval: Constants.retryDelaySeconds)
+            Thread.sleep(forTimeInterval: Constants.waitingDelaySeconds)
             sendTransaction(serializedTransaction: serializedTransaction,
                             configs: configs,
                             startSendingTimestamp: startSendingTimestamp,
@@ -92,6 +92,7 @@ private extension Api {
     enum Constants {
         /// According to blockchain specifications and blockhain analytic
         static let retryStartTimeoutSeconds: TimeInterval = 15
+        static let waitingDelaySeconds: TimeInterval = 1
         static let retryDelaySeconds: TimeInterval = 3
         static let maxRetries: TimeInterval = 5
     }

--- a/Sources/Solana/Networking/Router/NetworkingRouter.swift
+++ b/Sources/Solana/Networking/Router/NetworkingRouter.swift
@@ -15,6 +15,15 @@ public enum RPCError: Error {
     case invalidResponse(ResponseError)
     case unknownResponse
     case retry
+
+    public var isBlockhashNotFoundError: Bool {
+        switch self {
+        case .invalidResponse(let reponseError):
+            reponseError.code == -32002
+        default:
+            false
+        }
+    }
 }
 
 public protocol NetworkingRouterSwitchApiLogger {


### PR DESCRIPTION
Переходим на другой тип коммитмента по блокхешу. Для нас это значит следующее, что транзакцию не получится отправить слишком быстро, мы будем повторять попытки отправить в течение 18 секунд, после получения блокхеша. Время записывается в момент перед подписью. В случае со стейккитом в момент начала операции отправки. Проверил несколько транзакций, все улетели